### PR TITLE
Allow user to specify shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "parallel-sh"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parallel-sh"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["thyrc <thyrc@users.noreply.github.com>"]
 description = "Execute commands in parallel"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ What to expect:
 
 - Output (stdout and stderr) of each child process is stored and printed only after the child exits.
 - There is some simple logging and some runtime metric (via -v, -vv or -vvv) available.
-- The whole crate is tiny, <300 lines of code (w/ ~25% command line argument parsing), and can quickly be modified to meet more complex requirements.
+- The whole crate is tiny, <350 lines of code (w/ ~25% command line argument parsing), and can quickly be modified to meet more complex requirements.
 
 What is not part of `parallel-sh`:
 
@@ -48,7 +48,8 @@ OPTIONS:
     -l, --log <FILE>        Log output to file
     -j, --jobs <THREADS>    Number of parallel executions
     -s, --shell <SHELL>     shell to use for command execution (defaults to powershell on windows, and sh everywhere else)
-
+                            Note: commands are executed via <SHELL> -c "command", therefore the provided shell must
+                            support the '-c' option.
 ARGS:
     <clijobs>...
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/thyrc/parallel-sh/workflows/Rust/badge.svg)](https://github.com/thyrc/parallel-sh/actions?query=workflow%3ARust)
 [![GitHub license](https://img.shields.io/github/license/thyrc/parallel-sh.svg)](https://github.com/thyrc/parallel-sh/blob/main/LICENSE)
 
-`parallel-sh` was heavily inspired by Rust Parallel ([parallel](https://crates.io/crates/parallel)) parallelizing 'otherwise non-parallel command-line tasks.' But instead of trying to recreate the full functionality of GNU Parallel `parallel-sh` will simply execute (lines of) commands in the platform's preferred shell ('sh -c' on Unix systems, and 'powershell.exe -c' on Windows) in separate threads.
+`parallel-sh` was heavily inspired by Rust Parallel ([parallel](https://crates.io/crates/parallel)) parallelizing 'otherwise non-parallel command-line tasks.' But instead of trying to recreate the full functionality of GNU Parallel `parallel-sh` will simply execute (lines of) commands in the platform's preferred shell (by default 'sh -c' on Unix systems, and 'powershell.exe -c' on Windows) in separate threads.
 
 What to expect:
 
@@ -47,6 +47,7 @@ OPTIONS:
     -f, --file <FILE>       Read commands from file (one command per line)
     -l, --log <FILE>        Log output to file
     -j, --jobs <THREADS>    Number of parallel executions
+    -s, --shell <SHELL>     shell to use for command execution (defaults to powershell on windows, and sh everywhere else)
 
 ARGS:
     <clijobs>...

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Most of the effects of these features can be achieved by processing the commands
 
 ## Options
 ```text
-parallel-sh 0.1.1
+parallel-sh 0.1.13
 Execute commands in parallel
 
 USAGE:

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,12 @@ fn start_workers(
 
 #[allow(clippy::too_many_lines)]
 fn main() {
+    let shell_help = if cfg!(target_os = "windows") {
+        "shell to use for command execution. Must support '-c' (defaults to powershell)"
+    } else {
+        "shell to use for command execution. Must support '-c' (defaults to sh)"
+    };
+
     let matches = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
@@ -227,7 +233,7 @@ fn main() {
                 .value_name("SHELL")
                 .value_parser(ValueParser::os_string())
                 .num_args(1)
-                .help("shell to use for command execution (defaults to powershell on windows, and sh everywhere else)"),
+                .help(shell_help),
         )
         .arg(
             Arg::new("jobsfile")


### PR DESCRIPTION
This change adds an option to allow a user to specify which shell shall parallel-sh use to run commands.
A use case here is to make sure that scripts on linux and windows (via cygwin e.g.) behave the same way.